### PR TITLE
Add support for "\a" command

### DIFF
--- a/tests/test_vexecute.py
+++ b/tests/test_vexecute.py
@@ -30,7 +30,6 @@ def test_bools_are_treated_as_strings(executor):
     run(executor, 'create table vcli_test.test(a boolean)')
     run(executor, 'insert into vcli_test.test values(True)')
     output = run(executor, 'select * from vcli_test.test', join=True)
-    print output
     assert output == dedent("""\
         +------+
         | a    |
@@ -198,3 +197,24 @@ def test_copy_from_local_csv(executor):
         | Bob    |    30 |
         | Cindy  |    40 |
         +--------+-------+""")
+
+
+@dbtest
+def test_special_command_align_mode(executor, vspecial):
+    output = run(executor, "select 'Alice' as name, 20 as age",
+                 vspecial=vspecial, join=True)
+    assert output == dedent("""\
+        +--------+-------+
+        | name   |   age |
+        |--------+-------|
+        | Alice  |    20 |
+        +--------+-------+""")
+
+    output = run(executor, '\\a', vspecial=vspecial, join=True)
+    assert 'unaligned' in output
+
+    output = run(executor, "select 'Alice' as name, 20 as age",
+                 vspecial=vspecial, aligned=False, join=True)
+    assert output == dedent("""\
+        name|age
+        Alice|20""")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,12 +46,13 @@ def drop_schema(conn):
         cur.execute('DROP SCHEMA vcli_test CASCADE')
 
 
-def run(executor, sql, join=False, expanded=False, vspecial=None):
+def run(executor, sql, join=False, expanded=False, vspecial=None,
+        aligned=True):
     " Return string output for the sql to be run "
     result = []
     for title, rows, headers, status in executor.run(sql, vspecial):
         result.extend(format_output(title, rows, headers, status, 'psql',
-                                    expanded=expanded))
+                                    expanded=expanded, aligned=aligned))
     if join:
         result = '\n'.join(result)
     return result

--- a/vcli/main.py
+++ b/vcli/main.py
@@ -449,7 +449,7 @@ def format_output(title, cur, headers, status, table_format, expanded=False,
         else:
             if aligned:
                 numalign, stralign = 'decimal', 'left'
-                tablefmt = vtablefmt.vsv_aligned
+                tablefmt = table_format
             else:
                 numalign, stralign = None, None
                 tablefmt = vtablefmt.vsv_unaligned

--- a/vcli/packages/vspecial/main.py
+++ b/vcli/packages/vspecial/main.py
@@ -1,4 +1,5 @@
 import logging
+
 from collections import namedtuple
 
 from . import export
@@ -32,9 +33,12 @@ class VSpecial(object):
 
         self.commands = self.default_commands.copy()
 
+        self.aligned = True
         self.timing_enabled = False
         self.expanded_output = False
 
+        self.register(self.toggle_align, '\\a', '\\a', 'Aligned or unaligned',
+                      arg_type=NO_QUERY)
         self.register(self.show_help, '\\?', '\\?', 'Show help',
                       arg_type=NO_QUERY)
         self.register(self.show_help, '\\h', '\\h', 'Show help',
@@ -69,6 +73,15 @@ class VSpecial(object):
             return special_cmd.handler(cur=cur, pattern=pattern, verbose=verbose)
         elif special_cmd.arg_type == RAW_QUERY:
             return special_cmd.handler(cur=cur, query=sql)
+
+    def toggle_align(self):
+        self.aligned = not self.aligned
+        message = 'Output format is '
+        if self.aligned:
+            message += 'aligned.'
+        else:
+            message += 'unaligned.'
+        return [(None, None, None, message)]
 
     def show_help(self):
         headers = ['Command', 'Description']

--- a/vcli/packages/vtablefmt.py
+++ b/vcli/packages/vtablefmt.py
@@ -1,0 +1,19 @@
+from .tabulate import TableFormat, Line, DataRow
+
+
+# "Vertica-bar" seperated values
+vsv_aligned = TableFormat(lineabove=None,
+                          linebelowheader=Line('', '-', '+', ''),
+                          linebetweenrows=None,
+                          linebelow=None,
+                          headerrow=DataRow('', '|', ''),
+                          datarow=DataRow('', '|', ''),
+                          padding=1, with_header_hide=None)
+
+vsv_unaligned = TableFormat(lineabove=None,
+                            linebelowheader=None,
+                            linebetweenrows=None,
+                            linebelow=None,
+                            headerrow=DataRow('', '|', ''),
+                            datarow=DataRow('', '|', ''),
+                            padding=0, with_header_hide=None)

--- a/vcli/packages/vtablefmt.py
+++ b/vcli/packages/vtablefmt.py
@@ -2,14 +2,6 @@ from .tabulate import TableFormat, Line, DataRow
 
 
 # "Vertica-bar" seperated values
-vsv_aligned = TableFormat(lineabove=None,
-                          linebelowheader=Line('', '-', '+', ''),
-                          linebetweenrows=None,
-                          linebelow=None,
-                          headerrow=DataRow('', '|', ''),
-                          datarow=DataRow('', '|', ''),
-                          padding=1, with_header_hide=None)
-
 vsv_unaligned = TableFormat(lineabove=None,
                             linebelowheader=None,
                             linebetweenrows=None,

--- a/vcli/vclirc
+++ b/vcli/vclirc
@@ -31,7 +31,7 @@ timing = True
 # Table format. Possible values: psql, plain, simple, grid, fancy_grid, pipe,
 # orgtbl, rst, mediawiki, html, latex, latex_booktabs.
 # Recommended: psql, fancy_grid and grid.
-# table_format = psql
+table_format = psql
 
 # Syntax Style. Possible values: manni, igor, xcode, vim, autumn, vs, rrt,
 # native, perldoc, borland, tango, emacs, friendly, monokai, paraiso-dark,

--- a/vcli/vclirc
+++ b/vcli/vclirc
@@ -31,7 +31,7 @@ timing = True
 # Table format. Possible values: psql, plain, simple, grid, fancy_grid, pipe,
 # orgtbl, rst, mediawiki, html, latex, latex_booktabs.
 # Recommended: psql, fancy_grid and grid.
-table_format = psql
+# table_format = psql
 
 # Syntax Style. Possible values: manni, igor, xcode, vim, autumn, vs, rrt,
 # native, perldoc, borland, tango, emacs, friendly, monokai, paraiso-dark,


### PR DESCRIPTION
This PR implements the `\a` command that is provided in the official `vsql`. Unlike PostgreSQL, Vertica doesn't have dump tool to export data. Instead, we use `\a` with `\t` and `\o` (to be implemented) commands to export the data to a CSV-like file. See https://my.vertica.com/docs/7.1.x/HTML/index.htm#Authoring/ConnectingToHPVertica/vsql/ExportingDataUsingVsql.htm.

Example:

```
demo=> select * from people;
+--------+-------+-------------------+----------+
| name   | sex   | email             |    phone |
|--------+-------+-------------------+----------|
| Alice  | F     | alice@example.com | 12345678 |
| Bob    | M     | bob@example.com   | 23456789 |
| Cindy  | F     | cindy@example.com | 98876653 |
| David  | M     | david@example.com |  9473749 |
+--------+-------+-------------------+----------+
(4 rows)
Time: command: 0.000s, total: 0.002s
demo=> \a
Output format is unaligned.
Time: command: 0.000s, total: 0.000s
demo=> select * from people;
name|sex|email|phone
Alice|F|alice@example.com|12345678
Bob|M|bob@example.com|23456789
Cindy|F|cindy@example.com|98876653
David|M|david@example.com|9473749
(4 rows)
Time: command: 0.000s, total: 0.001s
```
