### PR TITLE
Add support for "\t" command

### DIFF
--- a/tests/test_vexecute.py
+++ b/tests/test_vexecute.py
@@ -218,3 +218,24 @@ def test_special_command_align_mode(executor, vspecial):
     assert output == dedent("""\
         name|age
         Alice|20""")
+
+
+@dbtest
+def test_special_command_hide_header(executor, vspecial):
+    output = run(executor, "select 'Alice' as name, 20 as age",
+                 vspecial=vspecial, join=True)
+    assert output == dedent("""\
+        +--------+-------+
+        | name   |   age |
+        |--------+-------|
+        | Alice  |    20 |
+        +--------+-------+""")
+
+    output = run(executor, '\\t', vspecial=vspecial, join=True)
+    assert 'Hiding header' in output
+
+    output = run(executor, "select 'Alice' as name, 20 as age",
+                 vspecial=vspecial, aligned=False, show_header=False,
+                 join=True)
+    assert output == dedent("""\
+        Alice|20""")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,12 +47,13 @@ def drop_schema(conn):
 
 
 def run(executor, sql, join=False, expanded=False, vspecial=None,
-        aligned=True):
+        aligned=True, show_header=True):
     " Return string output for the sql to be run "
     result = []
     for title, rows, headers, status in executor.run(sql, vspecial):
         result.extend(format_output(title, rows, headers, status, 'psql',
-                                    expanded=expanded, aligned=aligned))
+                                    expanded=expanded, aligned=aligned,
+                                    show_header=show_header))
     if join:
         result = '\n'.join(result)
     return result

--- a/vcli/main.py
+++ b/vcli/main.py
@@ -278,7 +278,8 @@ class VCli(object):
                         formatted = format_output(title, cur, headers, status,
                                                   self.table_format,
                                                   self.vspecial.expanded_output,
-                                                  self.vspecial.aligned)
+                                                  self.vspecial.aligned,
+                                                  self.vspecial.show_header)
                         output.extend(formatted)
                         if hasattr(cur, 'rowcount'):
                             if cur.rowcount == 1:
@@ -432,7 +433,7 @@ def cli(database, host, port, user, prompt_passwd, password, version, vclirc):
 
 
 def format_output(title, cur, headers, status, table_format, expanded=False,
-                  aligned=True):
+                  aligned=True, show_header=True):
     output = []
     if title:  # Only print the title if it's not None.
         output.append(title)
@@ -453,6 +454,8 @@ def format_output(title, cur, headers, status, table_format, expanded=False,
             else:
                 numalign, stralign = None, None
                 tablefmt = vtablefmt.vsv_unaligned
+            if not show_header:
+                headers = []
             output.append(tabulate(rows, headers, numalign=numalign, stralign=stralign,
                                    tablefmt=tablefmt, missingval=''))
     if status:  # Only print the status if it's not None.

--- a/vcli/packages/vspecial/main.py
+++ b/vcli/packages/vspecial/main.py
@@ -34,10 +34,13 @@ class VSpecial(object):
         self.commands = self.default_commands.copy()
 
         self.aligned = True
+        self.show_header = True
         self.timing_enabled = False
         self.expanded_output = False
 
         self.register(self.toggle_align, '\\a', '\\a', 'Aligned or unaligned',
+                      arg_type=NO_QUERY)
+        self.register(self.toggle_header, '\\t', '\\t', 'Toggle header',
                       arg_type=NO_QUERY)
         self.register(self.show_help, '\\?', '\\?', 'Show help',
                       arg_type=NO_QUERY)
@@ -81,6 +84,15 @@ class VSpecial(object):
             message += 'aligned.'
         else:
             message += 'unaligned.'
+        return [(None, None, None, message)]
+
+    def toggle_header(self):
+        self.show_header = not self.show_header
+        if self.show_header:
+            message = 'Showing '
+        else:
+            message = 'Hiding '
+        message += 'header.'
         return [(None, None, None, message)]
 
     def show_help(self):


### PR DESCRIPTION
Continue the work of #12, this PR implements the `\t` special command, which toggles the column header.
