### PR TITLE
Add support for \o command

### DIFF
--- a/tests/features/crud_table.feature
+++ b/tests/features/crud_table.feature
@@ -1,7 +1,6 @@
 Feature: manipulate tables:
   create, insert, update, select, delete from, drop
 
-  @wip
   Scenario: create, insert, select from, update, drop table
      Given we have vcli installed
       when we run vcli without arguments
@@ -18,3 +17,44 @@ Feature: manipulate tables:
       then we see record deleted
       when we drop table
       then we see table dropped
+
+  Scenario: redirect output to file and stdout
+     Given we have vcli installed
+      when we run vcli without arguments
+      and we wait for prompt
+      and we create schema
+      then we see schema created
+      when we create table
+      then we see table created
+
+      when we insert into table
+      then we see record inserted
+
+      when we switch output verbosity
+      and we redirect output to file
+      and we select from table
+      and we wait for time prompt
+      and we wait for prompt
+      then we see result in file
+
+      when we switch output verbosity
+      and we redirect output to stdout
+      and we select from table
+      then we see result in stdout
+
+  @wip
+  Scenario: redirect unicode output to file
+     Given we have vcli installed
+      when we run vcli without arguments
+      and we wait for prompt
+      and we create schema
+      then we see schema created
+      when we create table
+      then we see table created
+
+      when we switch output verbosity
+      and we redirect output to file
+      and we select unicode data
+      and we wait for time prompt
+      and we wait for prompt
+      then wee see unicode result in file

--- a/tests/features/crud_table.feature
+++ b/tests/features/crud_table.feature
@@ -42,7 +42,6 @@ Feature: manipulate tables:
       and we select from table
       then we see result in stdout
 
-  @wip
   Scenario: redirect unicode output to file
      Given we have vcli installed
       when we run vcli without arguments

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -44,9 +44,14 @@ def after_scenario(context, _):
     """
     Cleans up after each test complete.
     """
-
     if hasattr(context, 'cli') and not context.exit_sent:
         context.cli.sendline('DROP SCHEMA IF EXISTS vcli_test CASCADE;')
+        context.cli.expect_exact('Refreshing completions', timeout=1)
+        context.cli.expect_exact('%s=>' % context.conf['dbname'], timeout=2)
 
         # Terminate nicely
         context.cli.terminate()
+
+    if hasattr(context, 'temp_filename'):
+        if os.path.exists(context.temp_filename):
+            os.remove(context.temp_filename)

--- a/tests/features/steps/step_definitions.py
+++ b/tests/features/steps/step_definitions.py
@@ -6,8 +6,11 @@ This string is used to call the step in "*.feature" file.
 """
 from __future__ import unicode_literals
 
+import codecs
 import getpass
 import os
+import re
+import tempfile
 
 import pexpect
 import pip
@@ -56,7 +59,7 @@ def step_run_cli_with_args(context):
     context.cli = pexpect.spawnu(cmd)
 
     if args['password']:
-        context.cli.expect_exact('Password:')
+        _expect_exact(context, 'Password:', timeout=1)
         context.cli.sendline(args['password'])
 
 
@@ -66,12 +69,17 @@ def step_run_cli_help(context):
     context.exit_sent = True
 
 
+@when('we wait for time prompt')
+def step_wait_time_prompt(context):
+    _expect_exact(context, 'Time: ', timeout=2)
+
+
 @when('we wait for prompt')
 def step_wait_prompt(context):
     """
     Make sure prompt is displayed.
     """
-    context.cli.expect('{0}=> '.format(context.conf['dbname']), timeout=7)
+    _expect_prompt(context, timeout=7)
 
 
 @when('we send "ctrl + d"')
@@ -130,7 +138,7 @@ def step_create_table(context):
     Send create table.
     """
     context.cli.sendline('create table vcli_test.people(name varchar(30));')
-    context.cli.expect('{0}=> '.format(context.conf['dbname']), timeout=2)
+    _expect_prompt(context, timeout=2)
 
 
 @when('we insert into table')
@@ -139,8 +147,8 @@ def step_insert_into_table(context):
     Send insert into table.
     """
     context.cli.sendline("insert into vcli_test.people (name) values('Bob');")
-    context.cli.expect(r'OUTPUT\s*\|', timeout=2)
-    context.cli.expect(r'1\s*\|', timeout=1)
+    _expect(context, r'OUTPUT\s*\|', timeout=2)
+    _expect(context, r'1\s*\|', timeout=1)
 
 
 @when('we update table')
@@ -149,8 +157,8 @@ def step_update_table(context):
     Send update table.
     """
     context.cli.sendline("update vcli_test.people set name = 'Alice';")
-    context.cli.expect(r'OUTPUT\s*\|', timeout=2)
-    context.cli.expect(r'1\s*\|', timeout=1)
+    _expect(context, r'OUTPUT\s*\|', timeout=2)
+    _expect(context, r'1\s*\|', timeout=1)
 
 
 @when('we delete from table')
@@ -159,8 +167,8 @@ def step_delete_from_table(context):
     Send delete from table.
     """
     context.cli.sendline('delete from vcli_test.people;')
-    context.cli.expect(r'OUTPUT\s*\|', timeout=2)
-    context.cli.expect(r'1\s*\|', timeout=1)
+    _expect(context, r'OUTPUT\s*\|', timeout=2)
+    _expect(context, r'1\s*\|', timeout=1)
 
 
 @when('we drop table')
@@ -180,17 +188,49 @@ def step_db_connect_database(context):
     context.cli.sendline('\\c %s' % dbname)
 
 
+@when('we switch output verbosity')
+def step_switch_output_verbosity(context):
+    context.cli.sendline('\\t')
+    _expect_exact(context, ' header.', timeout=1)
+    _expect_prompt(context, timeout=1)
+
+    context.cli.sendline('\\a')
+    _expect_exact(context, 'Output format is ', timeout=1)
+    _expect_prompt(context, timeout=1)
+
+
+@when('we redirect output to file')
+def step_redirect_output_to_file(context):
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        context.temp_filename = f.name
+    context.cli.sendline('\\o %s' % context.temp_filename)
+    _expect_exact(context, 'output to file.', timeout=1)
+    _expect_prompt(context, timeout=1)
+
+
+@when('we redirect output to stdout')
+def step_redirect_output_to_stdout(context):
+    context.cli.sendline('\\o')
+    _expect_exact(context, 'output to stdout.', timeout=1)
+    _expect_prompt(context, timeout=1)
+
+
+@when('we select from table')
+def step_select_table(context):
+    context.cli.sendline('select * from vcli_test.people;')
+
+
 @then('vcli exits')
 def step_wait_exit(context):
     """
     Make sure the cli exits.
     """
-    context.cli.expect(pexpect.EOF, timeout=2)
+    _expect_exact(context, pexpect.EOF, timeout=2)
 
 
 @then('we see vcli help')
 def step_see_cli_help(context):
-    context.cli.expect_exact('Usage: vcli ')
+    _expect_exact(context, 'Usage: vcli ', timeout=1)
 
 
 @then('we see vcli prompt')
@@ -198,16 +238,13 @@ def step_see_prompt(context):
     """
     Wait to see the prompt.
     """
-    context.cli.expect('{0}=> '.format(context.conf['dbname']), timeout=3)
+    _expect_prompt(context, timeout=3)
 
 
 @then('we see help output')
 def step_see_help(context):
     for expected_line in context.fixture_data['help_commands.txt']:
-        try:
-            context.cli.expect_exact(expected_line, timeout=3)
-        except pexpect.TIMEOUT:
-            assert False, 'Expected: ' + expected_line.strip()
+        _expect_exact(context, expected_line, timeout=2)
 
 
 @then('we see schema created')
@@ -216,7 +253,7 @@ def step_see_schema_created(context):
     Wait to see create database output.
     """
     context.cli.sendline('\\dn')
-    context.cli.expect(r'vcli_test\s*\|\s*%(user)s' % context.conf, timeout=2)
+    _expect(context, r'vcli_test\s*\|\s*%(user)s' % context.conf, timeout=2)
 
 
 @then('we see schema dropped')
@@ -239,7 +276,7 @@ def step_see_db_connected(context):
     """
     Wait to see drop database output.
     """
-    context.cli.expect_exact('You are now connected to database', timeout=2)
+    _expect_exact(context, 'You are now connected to database', timeout=2)
 
 
 @then('we see table created')
@@ -248,7 +285,7 @@ def step_see_table_created(context):
     Wait to see create table output.
     """
     context.cli.sendline('\\dt vcli_test.*')
-    context.cli.expect(r'vcli_test\s*\|\s*people', timeout=2)
+    _expect(context, r'vcli_test\s*\|\s*people', timeout=2)
 
 
 @then('we see record inserted')
@@ -257,7 +294,7 @@ def step_see_record_inserted(context):
     Wait to see insert output.
     """
     context.cli.sendline('select name from vcli_test.people;')
-    context.cli.expect(r'Bob\s*\|', timeout=2)
+    _expect(context, r'Bob\s*\|', timeout=2)
 
 
 @then('we see record updated')
@@ -266,7 +303,7 @@ def step_see_record_updated(context):
     Wait to see update output.
     """
     context.cli.sendline('select name from vcli_test.people;')
-    context.cli.expect(r'Alice\s*\|', timeout=2)
+    _expect(context, r'Alice\s*\|', timeout=2)
 
 
 @then('we see record deleted')
@@ -275,8 +312,22 @@ def step_see_data_deleted(context):
     Wait to see delete output.
     """
     context.cli.sendline('select count(1) as rowcount from vcli_test.people;')
-    context.cli.expect(r'rowcount\s*\|', timeout=2)
-    context.cli.expect(r'0\s*\|', timeout=1)
+    _expect(context, r'rowcount\s*\|', timeout=2)
+    _expect(context, r'0\s*\|', timeout=1)
+
+
+@then('we see result in file')
+def step_see_result_in_file(context):
+    assert os.path.exists(context.temp_filename)
+    with open(context.temp_filename) as f:
+        content = f.read()
+    assert content == 'Bob', "'%s' != 'Bob'" % content
+
+
+@then('we see result in stdout')
+def step_see_result_in_stdout(context):
+    _expect(context, r'Bob\s*\|', timeout=2)
+    _expect(context, r'1 row', timeout=1)
 
 
 @then('we see table dropped')
@@ -285,9 +336,53 @@ def step_see_table_dropped(context):
     Wait to see drop output.
     """
     context.cli.sendline('\\dt vcli_test')
+
     try:
         context.cli.expect(r'vcli_test\s*\|\s*people', timeout=2)
     except pexpect.TIMEOUT:
         pass
     else:
-        assert False, "Table 'vcli_test.people' should not exist"
+        raise AssertionError("Table 'vcli_test.people' should not exist")
+
+
+@when(u'we select unicode data')
+def step_select_unicode(context):
+    context.cli.sendline(u"SELECT '中文' AS chinese;")
+
+
+@then(u'wee see unicode result in file')
+def step_see_unicode_in_file(context):
+    assert os.path.exists(context.temp_filename)
+    with codecs.open(context.temp_filename, encoding='utf-8') as f:
+        content = f.read()
+    assert content == '中文', "'%s' != '中文'" % content
+
+
+def _strip_color(s):
+    return re.sub(r'\x1b\[([0-9A-Za-z;?])+[m|K]?', '', s)
+
+
+def _expect_exact(context, expected, timeout=1):
+    try:
+        context.cli.expect_exact(expected, timeout=timeout)
+    except:
+        # Strip color codes out of the output.
+        actual = _strip_color(context.cli.before)
+        raise AssertionError('Expected:\n---\n{0}\n---\n\nActual:\n---\n{1}\n---'.format(
+            expected,
+            actual))
+
+
+def _expect(context, expected, timeout=1):
+    try:
+        context.cli.expect(expected, timeout=timeout)
+    except:
+        actual = _strip_color(context.cli.before)
+        raise AssertionError('Expected:\n---\n{0}\n---\n\nActual:\n---\n{1}\n---'.format(
+            expected,
+            actual))
+
+
+def _expect_prompt(context, timeout=1):
+    dbname = context.conf['dbname']
+    _expect_exact(context, '{0}=> '.format(dbname), timeout=timeout)

--- a/tests/features/steps/step_definitions.py
+++ b/tests/features/steps/step_definitions.py
@@ -319,8 +319,8 @@ def step_see_data_deleted(context):
 @then('we see result in file')
 def step_see_result_in_file(context):
     assert os.path.exists(context.temp_filename)
-    with open(context.temp_filename) as f:
-        content = f.read()
+    with codecs.open(context.temp_filename, encoding='utf-8') as f:
+        content = f.read().strip()
     assert content == 'Bob', "'%s' != 'Bob'" % content
 
 
@@ -354,8 +354,8 @@ def step_select_unicode(context):
 def step_see_unicode_in_file(context):
     assert os.path.exists(context.temp_filename)
     with codecs.open(context.temp_filename, encoding='utf-8') as f:
-        content = f.read()
-    assert content == '中文', "'%s' != '中文'" % content
+        content = f.read().strip()
+    assert content == u'中文', u"'%s' != '中文'" % content
 
 
 def _strip_color(s):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -51,7 +51,7 @@ def run(executor, sql, join=False, expanded=False, vspecial=None,
         aligned=True, show_header=True):
     " Return string output for the sql to be run "
     result = []
-    for title, rows, headers, status in executor.run(sql, vspecial):
+    for title, rows, headers, status, force_stdout in executor.run(sql, vspecial):
         result.extend(format_output(title, rows, headers, status, 'psql',
                                     expanded=expanded, aligned=aligned,
                                     show_header=show_header))

--- a/vcli/packages/vspecial/dbcommands.py
+++ b/vcli/packages/vspecial/dbcommands.py
@@ -35,7 +35,7 @@ def list_objects(cur, pattern, verbose, columns, table_name,
     cur.execute(sql)
 
     headers = [x[0] for x in cur.description]
-    return [(title, cur, headers, None)]
+    return [(title, cur, headers, None, False)]
 
 
 @special_command('\\d', '\\d [PATTERN]', 'List or describe tables')
@@ -55,7 +55,7 @@ def describe_table_details(cur, pattern, verbose):
         cur.execute(sql)
         if cur.description:
             headers = [x[0] for x in cur.description]
-            return [(None, cur, headers, None)]
+            return [(None, cur, headers, None, False)]
 
     # This is a \d <tablename> command. A royal pain in the ass.
     schema, relname = sql_name_pattern(pattern)
@@ -86,7 +86,7 @@ def describe_table_details(cur, pattern, verbose):
     cur.execute(sql)
 
     headers = [x[0] for x in cur.description]
-    return [(None, cur, headers, None)]
+    return [(None, cur, headers, None, False)]
 
 
 @special_command('\\df', '\\df [PATTERN]', 'List functions')
@@ -223,7 +223,7 @@ def list_tables_and_views(cur, pattern, verbose):
 
     if cur.description:
         headers = [x[0] for x in cur.description]
-        return [(None, cur, headers, None)]
+        return [(None, cur, headers, None, False)]
     return None
 
 

--- a/vcli/packages/vspecial/iocommands.py
+++ b/vcli/packages/vspecial/iocommands.py
@@ -76,16 +76,16 @@ def execute_from_file(cur, pattern, **_):
         except IOError as e:
             message = 'Error reading file: %s' % pattern
             message = message + ' Error was: ' + str(e)
-            return [(None, None, None, message)]
+            return [(None, None, None, message, True)]
     else:
         message = '\\i: missing required argument'
-        return [(None, None, None, message)]
+        return [(None, None, None, message, True)]
     cur.execute(query)
     if cur.description:
         headers = [x[0] for x in cur.description]
-        return [(None, cur, headers, cur.statusmessage)]
+        return [(None, cur, headers, cur.statusmessage, False)]
     else:
-        return [(None, None, None, cur.statusmessage)]
+        return [(None, None, None, cur.statusmessage, True)]
 
 def read_from_file(path):
     with open(expanduser(path), encoding='utf-8') as f:
@@ -102,13 +102,13 @@ def execute_named_query(cur, pattern, **_):
     title = '> {}'.format(query)
     if query is None:
         message = "No named query: {}".format(pattern)
-        return [(None, None, None, message)]
+        return [(None, None, None, message, True)]
     cur.execute(query)
     if cur.description:
         headers = [x[0] for x in cur.description]
-        return [(title, cur, headers, None)]
+        return [(title, cur, headers, None, False)]
     else:
-        return [(title, None, None, None)]
+        return [(title, None, None, None, True)]
 
 def list_named_queries(verbose):
     """List of all named queries.
@@ -124,7 +124,7 @@ def list_named_queries(verbose):
         status = namedqueries.usage
     else:
         status = ''
-    return [('', rows, headers, status)]
+    return [('', rows, headers, status, True)]
 
 @special_command('\\ns', '\\ns NAME QUERY', 'Save a named query')
 def save_named_query(pattern, **_):
@@ -133,17 +133,17 @@ def save_named_query(pattern, **_):
 
     usage = 'Syntax: \\ns name query.\n\n' + namedqueries.usage
     if not pattern:
-        return [(None, None, None, usage)]
+        return [(None, None, None, usage, True)]
 
     name, _, query = pattern.partition(' ')
 
     # If either name or query is missing then print the usage and complain.
     if (not name) or (not query):
         return [(None, None, None,
-            usage + 'Err: Both name and query are required.')]
+            usage + 'Err: Both name and query are required.', True)]
 
     namedqueries.save(name, query)
-    return [(None, None, None, "Saved.")]
+    return [(None, None, None, "Saved.", True)]
 
 @special_command('\\nd', '\\nd [NAME]', 'Delete a named query')
 def delete_named_query(pattern, **_):
@@ -151,8 +151,8 @@ def delete_named_query(pattern, **_):
     """
     usage = 'Syntax: \\nd name.\n\n' + namedqueries.usage
     if not pattern:
-        return [(None, None, None, usage)]
+        return [(None, None, None, usage, True)]
 
     status = namedqueries.delete(pattern)
 
-    return [(None, None, None, status)]
+    return [(None, None, None, status, True)]

--- a/vcli/vexecute.py
+++ b/vcli/vexecute.py
@@ -133,12 +133,13 @@ class VExecute(object):
 
         :param statement: A string containing one or more sql statements
         :param vspecial: VSpecial object
-        :return: List of tuples containing (title, rows, headers, status)
+        :return: List of tuples containing (title, rows, headers, status,
+                                            force_stdout)
         """
         # Remove spaces and EOL
         statement = statement.strip()
         if not statement:  # Empty string
-            yield (None, None, None, None)
+            yield (None, None, None, None, True)
 
         # Split the sql into separate queries and run each one.
         for sql in sqlparse.split(statement):
@@ -174,10 +175,10 @@ class VExecute(object):
         if cur.description and first_token in ('select', 'update', 'delete',
                                                'insert'):
             headers = [x[0] for x in cur.description]
-            return (title, cur, headers, statusmessage)
+            return (title, cur, headers, statusmessage, False)
         else:
             _logger.debug('No rows in result.')
-            return (title, None, None, statusmessage)
+            return (title, None, None, statusmessage, True)
 
     def search_path(self):
         """Returns the current search path as a list of schema names"""


### PR DESCRIPTION
`\o` command redirects output from stdout to a file. But we can't just redirect everything to the file. Some of the output, such as special command results, still need to go to stdout even if the file mode is on. For this purpose, I added a `force_stdout` boolean to the the command output tuple, so it becomes `(title, rows, header, status, force_stdout)`. This boolean indicates if the message should go to stdout no matter what the current output destination is.
