### PR TITLE
Format error message better in a long SQL

### DIFF
--- a/vcli/verror.py
+++ b/vcli/verror.py
@@ -25,6 +25,33 @@ def format_error(error):
     if match:
         sql = error.one_line_sql()
         position = int(match.group(1))
+
+        # Truncate the SQL query if its length > n (n must be odd)
+        n = 75
+        d = (n - 1) / 2
+        length = len(sql)
+        if length > n:
+            left = position - d
+            right = position + d
+            position = d
+            head = '...'
+            tail = '...'
+
+            if left < 0:
+                right -= left
+                position += left
+                left = 0
+                head = ''
+            elif right >= length:
+                offset = right - length + 1
+                left -= offset
+                position += offset
+                right = length - 1
+                tail = ''
+
+            sql = head + sql[left:right + 1] + tail
+            position += len(head)
+
         result += ('\n%s\n' % sql) + (' ' * (position - 1)) + '^'
 
     return result


### PR DESCRIPTION
Before:

```
localdev=> select name, age form people where name = 'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong value';
ERROR 42601: Syntax error at or near "people"
select name, age form people where name = 'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong value'
                      ^
```

After:

```
localdev=> select name, age form people where name = 'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong value';
ERROR 42601: Syntax error at or near "people"
select name, age form people where name = 'looooooooooooooooooooooooooooooo...
                      ^
```
