### PR TITLE
fixing regex to allow uppercase letters in schema names

### DIFF
--- a/vcli/vcompleter.py
+++ b/vcli/vcompleter.py
@@ -62,7 +62,7 @@ class VCompleter(Completer):
         self.reserved_words = set()
         for x in self.keywords:
             self.reserved_words.update(x.split())
-        self.name_pattern = re.compile("^[_a-z][_a-z0-9\$]*$")
+        self.name_pattern = re.compile("^[_a-zA-Z][_a-zA-Z0-9\$]*$")
 
         self.databases = []
         self.dbmetadata = {'tables': {}, 'views': {}, 'functions': {},


### PR DESCRIPTION
Fix for issue #52 

The modified regex will populate schema names in the autocomplete list without enclosing in double quotes.